### PR TITLE
Fix php 8.1 compatibility in Pipeline::handle()

### DIFF
--- a/src/MessageBus/Pipeline.php
+++ b/src/MessageBus/Pipeline.php
@@ -36,11 +36,7 @@ final class Pipeline
      */
     public static function handle(MessageContext $messageContext, Handler $handler, iterable $middlewares): mixed
     {
-        /**
-         * @psalm-suppress InvalidArgument
-         * @var list<Middleware>
-         */
-        $middlewares = iterator_to_array($middlewares, preserve_keys: false);
+        $middlewares = $middlewares instanceof \Traversable ? iterator_to_array($middlewares, preserve_keys: false) : array_values($middlewares);
 
         if ($middlewares === []) {
             return $handler->handle($messageContext);


### PR DESCRIPTION
`0.1.x` compatible with php 8.1.

Function `iterator_to_array` expects `\Traversable|array` type of argument `$iterator` starting php 8.2. But in php 8.1 expects only `\Traversable`.

There will be a fatal error in php < 8.2:

https://3v4l.org/GYpD6