### PR TITLE
Test HandlerRegistry implementations

### DIFF
--- a/src/MessageBus/HandlerRegistry.php
+++ b/src/MessageBus/HandlerRegistry.php
@@ -7,6 +7,7 @@ namespace Telephantast\MessageBus;
 use Telephantast\Message\Event;
 use Telephantast\Message\Message;
 use Telephantast\MessageBus\Handler\CallableHandler;
+use Telephantast\MessageBus\HandlerRegistry\HandlerNotFound;
 
 /**
  * @api
@@ -18,6 +19,7 @@ abstract class HandlerRegistry
      * @template TMessage of Message<TResult>
      * @param class-string<TMessage> $messageClass
      * @return Handler<TResult, TMessage>
+     * @throws HandlerNotFound
      */
     final public function get(string $messageClass): Handler
     {
@@ -32,7 +34,7 @@ abstract class HandlerRegistry
             return new CallableHandler('null event handler', static fn(): mixed => null);
         }
 
-        throw new \RuntimeException(\sprintf('No handler for non-event message %s', $messageClass));
+        throw new HandlerNotFound(\sprintf('No handler for non-event message %s', $messageClass));
     }
 
     /**

--- a/src/MessageBus/HandlerRegistry/HandlerNotFound.php
+++ b/src/MessageBus/HandlerRegistry/HandlerNotFound.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telephantast\MessageBus\HandlerRegistry;
+
+/**
+ * @api
+ */
+final class HandlerNotFound extends \RuntimeException {}

--- a/tests/MessageBus/HandlerRegistry/ArrayHandlerRegistryTest.php
+++ b/tests/MessageBus/HandlerRegistry/ArrayHandlerRegistryTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telephantast\MessageBus\HandlerRegistry;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Telephantast\MessageBus\HandlerRegistry;
+
+/**
+ * @internal
+ */
+#[CoversClass(className: ArrayHandlerRegistry::class)]
+final class ArrayHandlerRegistryTest extends HandlerRegistryTestCase
+{
+    protected function createHandlerRegistry(array $messageClassToHandler): HandlerRegistry
+    {
+        return new ArrayHandlerRegistry($messageClassToHandler);
+    }
+}

--- a/tests/MessageBus/HandlerRegistry/HandlerRegistryTestCase.php
+++ b/tests/MessageBus/HandlerRegistry/HandlerRegistryTestCase.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telephantast\MessageBus\HandlerRegistry;
+
+use PHPUnit\Framework\TestCase;
+use Telephantast\Message\Message;
+use Telephantast\MessageBus\Handler;
+use Telephantast\MessageBus\HandlerRegistry;
+use Telephantast\MessageBus\TestEvent;
+use Telephantast\MessageBus\TestHandler;
+use Telephantast\MessageBus\TestMessage;
+
+/**
+ * @internal
+ */
+abstract class HandlerRegistryTestCase extends TestCase
+{
+    /**
+     * @template TResult
+     * @template TMessage of Message<TResult>
+     * @param array<class-string<TMessage>, Handler<TResult, TMessage>> $messageClassToHandler
+     */
+    abstract protected function createHandlerRegistry(array $messageClassToHandler): HandlerRegistry;
+
+    final public function testGet(): void
+    {
+        $handler = new TestHandler();
+
+        $handlerRegistry = $this->createHandlerRegistry([
+            TestMessage::class => $handler,
+        ]);
+
+        self::assertSame($handler, $handlerRegistry->get(TestMessage::class));
+    }
+
+    final public function testGetHandlerNotFound(): void
+    {
+        self::expectException(HandlerNotFound::class);
+
+        $handlerRegistry = $this->createHandlerRegistry([]);
+
+        $handlerRegistry->get(TestMessage::class);
+    }
+
+    final public function testGetHandlerForEventNotFound(): void
+    {
+        $handlerRegistry = $this->createHandlerRegistry([]);
+
+        $handler = $handlerRegistry->get(TestEvent::class);
+
+        self::assertInstanceOf(Handler\CallableHandler::class, $handler);
+    }
+
+    final public function testFind(): void
+    {
+        $handler = new TestHandler();
+
+        $handlerRegistry = $this->createHandlerRegistry([
+            TestMessage::class => $handler,
+        ]);
+
+        self::assertSame($handler, $handlerRegistry->find(TestMessage::class));
+    }
+
+    final public function testFindHandlerNotFound(): void
+    {
+        $handlerRegistry = $this->createHandlerRegistry([]);
+
+        self::assertNull($handlerRegistry->find(TestMessage::class));
+    }
+}

--- a/tests/MessageBus/HandlerRegistry/PsrContainerHandlerRegistryTest.php
+++ b/tests/MessageBus/HandlerRegistry/PsrContainerHandlerRegistryTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telephantast\MessageBus\HandlerRegistry;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use Telephantast\MessageBus\HandlerRegistry;
+use Telephantast\Psr\Container\ArrayPsrContainer;
+
+/**
+ * @internal
+ */
+#[CoversClass(className: PsrContainerHandlerRegistry::class)]
+final class PsrContainerHandlerRegistryTest extends HandlerRegistryTestCase
+{
+    protected function createHandlerRegistry(array $messageClassToHandler): HandlerRegistry
+    {
+        return new PsrContainerHandlerRegistry(
+            new ArrayPsrContainer($messageClassToHandler),
+        );
+    }
+}

--- a/tests/MessageBus/TestEvent.php
+++ b/tests/MessageBus/TestEvent.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telephantast\MessageBus;
+
+use Telephantast\Message\Event;
+
+/**
+ * @internal
+ */
+final class TestEvent implements Event {}

--- a/tests/MessageBus/TestHandler.php
+++ b/tests/MessageBus/TestHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telephantast\MessageBus;
+
+/**
+ * @internal
+ * @implements Handler<void, TestMessage>
+ */
+final class TestHandler implements Handler
+{
+    public function id(): string
+    {
+        return 'test';
+    }
+
+    public function handle(MessageContext $messageContext): mixed
+    {
+        return null;
+    }
+}

--- a/tests/MessageBus/TestMessage.php
+++ b/tests/MessageBus/TestMessage.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telephantast\MessageBus;
+
+use Telephantast\Message\Message;
+
+/**
+ * @internal
+ * @implements Message<void>
+ */
+final class TestMessage implements Message {}

--- a/tests/Psr/Container/ArrayPsrContainer.php
+++ b/tests/Psr/Container/ArrayPsrContainer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Telephantast\Psr\Container;
+
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * @internal
+ * @template-covariant TItem
+ * @implements ContainerInterface<TItem>
+ */
+final class ArrayPsrContainer implements ContainerInterface
+{
+    /**
+     * @param array<string, TItem> $items
+     */
+    public function __construct(
+        private readonly array $items,
+    ) {}
+
+    public function get(string $id): mixed
+    {
+        return $this->items[$id]
+            ?? throw new class (\sprintf('Item with key "%s" not found.', $id)) extends \RuntimeException implements NotFoundExceptionInterface {};
+    }
+
+    public function has(string $id): bool
+    {
+        return \array_key_exists($id, $this->items);
+    }
+}


### PR DESCRIPTION
- Create specific `HandlerNotFound` exception. It can be thrown in `HandlerRegistry::get()` instead `\RuntimeException`
- Create abstract `HandlerRegistryTestCase` for testing `HandlerRegistry` implementations
- Test `ArrayHandlerRegistry` and `PsrContainerHandlerRegistry`