### PR TITLE
Add doctrine/orm to telephantast/doctrine-persistence dependencies

### DIFF
--- a/src/DoctrinePersistence/composer.json
+++ b/src/DoctrinePersistence/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": "^8.1",
         "doctrine/dbal": "^3 || ^4",
+        "doctrine/orm": "^3.2",
         "telephantast/message-bus": "^0.1@dev"
     },
     "autoload": {


### PR DESCRIPTION
- DoctrineOrmTransactionProvider depends of doctrine/orm
- DoctrineOrmEntityFinderAndSaver depends of doctrine/persistence