### PR TITLE
Change DoctrinePostgresOutboxStorage message_id to text

### DIFF
--- a/src/DoctrinePersistence/DoctrinePostgresOutboxStorage.php
+++ b/src/DoctrinePersistence/DoctrinePostgresOutboxStorage.php
@@ -29,7 +29,7 @@ final class DoctrinePostgresOutboxStorage implements OutboxStorage
     {
         $table = $schema->createTable($this->table);
         $table->addColumn('queue', Types::TEXT);
-        $table->addColumn('message_id', Types::GUID);
+        $table->addColumn('message_id', Types::TEXT);
         $table->addColumn('outbox', Types::BINARY);
         $table->setPrimaryKey(['message_id', 'queue']);
     }


### PR DESCRIPTION
MessageId can any non-empty-string, not only valid uuid string.